### PR TITLE
feat: add start_date to Mensaje model for Gantt support

### DIFF
--- a/migrations/sql/001_add_start_date_to_mensaje.sql
+++ b/migrations/sql/001_add_start_date_to_mensaje.sql
@@ -1,0 +1,11 @@
+-- Migration: 001_add_start_date_to_mensaje
+-- Descripción: Agrega campo start_date a la tabla mensaje para soporte de Gantt
+-- Fecha: 2026-02-23
+
+ALTER TABLE mensaje ADD COLUMN IF NOT EXISTS start_date TIMESTAMP NULL;
+
+-- Verificar resultado
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_name = 'mensaje'
+ORDER BY ordinal_position;

--- a/src/main_routes.py
+++ b/src/main_routes.py
@@ -55,12 +55,22 @@ def api_crear_mensaje():
     if not data or not data.get("nombre") or not data.get("mensaje"):
         return jsonify({"error": "Faltan campos requeridos"}), 400
 
+    start_date = None
+    if data.get("start_date"):
+        try:
+            start_date = datetime.fromisoformat(data["start_date"])
+        except ValueError:
+            return jsonify({"error": "Formato de start_date inválido. Usa ISO 8601."}), 400
+
     expiration_date = None
     if data.get("expiration_date"):
         try:
             expiration_date = datetime.fromisoformat(data["expiration_date"])
         except ValueError:
-            return jsonify({"error": "Formato de fecha inválido. Usa ISO 8601."}), 400
+            return jsonify({"error": "Formato de expiration_date inválido. Usa ISO 8601."}), 400
+
+    if start_date and expiration_date and start_date > expiration_date:
+        return jsonify({"error": "start_date no puede ser mayor que expiration_date"}), 400
 
     nuevo = Mensaje(
         nombre=data["nombre"],
@@ -68,6 +78,7 @@ def api_crear_mensaje():
         usuario_id=int(user_id),
         estado=data.get("estado", "pendiente"),
         proyecto_id=data.get("proyecto_id"),
+        start_date=start_date,
         expiration_date=expiration_date
     )
     if not nuevo.proyecto_id:
@@ -83,6 +94,7 @@ def api_crear_mensaje():
             "nombre": nuevo.nombre,
             "mensaje": nuevo.mensaje,
             "estado": nuevo.estado,
+            "start_date": nuevo.start_date.isoformat() if nuevo.start_date else None,
             "expiration_date": nuevo.expiration_date.isoformat() if nuevo.expiration_date else None
         },
         "autor": user_id
@@ -143,6 +155,7 @@ def mis_mensajes():
          "created_at": m.created_at, 
          "updated_at": m.updated_at,
          "estado": m.estado,
+         "start_date": m.start_date.isoformat() if m.start_date else None,
          "expiration_date": m.expiration_date.isoformat() if m.expiration_date else None
          }
         for m in mensajes
@@ -162,11 +175,19 @@ def actualizar_mensaje(id):
 
     if "estado" in data:
         mensaje.estado = data["estado"]
+    if "start_date" in data:
+        try:
+            mensaje.start_date = datetime.fromisoformat(data["start_date"]) if data["start_date"] else None
+        except Exception as e:
+            return jsonify({"error": f"Formato de start_date inválido: {str(e)}"}), 400
     if "expiration_date" in data:
         try:
-            mensaje.expiration_date = datetime.fromisoformat(data["expiration_date"])
+            mensaje.expiration_date = datetime.fromisoformat(data["expiration_date"]) if data["expiration_date"] else None
         except Exception as e:
-            return jsonify({"error": f"Formato de fecha inválido: {str(e)}"}), 400
+            return jsonify({"error": f"Formato de expiration_date inválido: {str(e)}"}), 400
+    # Validar que start_date <= expiration_date
+    if mensaje.start_date and mensaje.expiration_date and mensaje.start_date > mensaje.expiration_date:
+        return jsonify({"error": "start_date no puede ser mayor que expiration_date"}), 400
     mensaje.updated_at = datetime.utcnow()
     mensaje.mensaje = data.get("mensaje", mensaje.mensaje)
     db.session.commit()
@@ -204,6 +225,7 @@ def duplicar_mensaje(id):
         usuario_id=mensaje.usuario_id,
         proyecto_id=mensaje.proyecto_id,
         estado=mensaje.estado,
+        start_date=mensaje.start_date,
         expiration_date=mensaje.expiration_date
     )
     db.session.add(nuevo)

--- a/src/models.py
+++ b/src/models.py
@@ -21,6 +21,7 @@ class Mensaje(db.Model):
     estado = db.Column(db.String(20), nullable=False, default='pendiente')
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    start_date = db.Column(db.DateTime, nullable=True)
     expiration_date = db.Column(db.DateTime, nullable=True)
 
     usuario_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=False)
@@ -37,6 +38,7 @@ class Mensaje(db.Model):
             "usuario_id": self.usuario_id,
             "proyecto_id": self.proyecto_id,
             "estado": self.estado,
+            "start_date": self.start_date.isoformat() if self.start_date else None,
             "expiration_date": self.expiration_date.isoformat() if self.expiration_date else None,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None

--- a/src/project_routes.py
+++ b/src/project_routes.py
@@ -99,7 +99,14 @@ def delete_proyecto(proyecto_id):
 def mensajes_de_proyecto(pid):
     p = Proyecto.query.get_or_404(pid)
     return jsonify([
-        {"id": m.id, "nombre": m.nombre, "mensaje": m.mensaje, "estado": m.estado}
+        {
+            "id": m.id,
+            "nombre": m.nombre,
+            "mensaje": m.mensaje,
+            "estado": m.estado,
+            "start_date": m.start_date.isoformat() if m.start_date else None,
+            "expiration_date": m.expiration_date.isoformat() if m.expiration_date else None
+        }
         for m in p.mensajes
     ])
 
@@ -112,11 +119,30 @@ def crear_mensaje(pid):
     if not data or not data.get("mensaje"):
         return jsonify({"error": "Faltan campos requeridos"}), 400
 
+    start_date = None
+    if data.get("start_date"):
+        try:
+            start_date = datetime.fromisoformat(data["start_date"])
+        except ValueError:
+            return jsonify({"error": "Formato de start_date inválido. Usa ISO 8601."}), 400
+
+    expiration_date = None
+    if data.get("expiration_date"):
+        try:
+            expiration_date = datetime.fromisoformat(data["expiration_date"])
+        except ValueError:
+            return jsonify({"error": "Formato de expiration_date inválido. Usa ISO 8601."}), 400
+
+    if start_date and expiration_date and start_date > expiration_date:
+        return jsonify({"error": "start_date no puede ser mayor que expiration_date"}), 400
+
     nuevo = Mensaje(
         nombre=data["nombre"],
         mensaje=data["mensaje"],
         proyecto_id=pid,
-        usuario_id= get_jwt_identity()
+        usuario_id=get_jwt_identity(),
+        start_date=start_date,
+        expiration_date=expiration_date
     )
     db.session.add(nuevo)
     db.session.commit()


### PR DESCRIPTION
- Add start_date (DateTime, nullable) column to Mensaje model
- Update to_dict() to include start_date
- Update POST /api/mensajes to accept and validate start_date
- Update PUT /api/mensajes/:id to accept and validate start_date
- Update GET /api/mis-mensajes to return start_date
- Update POST /api/proyectos/:id/mensajes with start_date + validation
- Update GET /api/proyectos/:id/mensajes to return start_date
- Update duplicar_mensaje to copy start_date
- Add validation: start_date must be <= expiration_date
- Add SQL migration file for Neon: migrations/sql/001_add_start_date_to_mensaje.sql

Closes #1, #2